### PR TITLE
Fix timeout in TCP handler

### DIFF
--- a/carbon_proxy/client.py
+++ b/carbon_proxy/client.py
@@ -157,7 +157,7 @@ async def tcp_handler(reader: asyncio.StreamReader,
                 line = await reader.readline()
             if line:
                 parse_line(line)
-        except asyncio.CancelledError:
+        except asyncio.TimeoutError:
             log.info('Client connection closed after timeout')
             break
         except ConnectionResetError:

--- a/carbon_proxy/client.py
+++ b/carbon_proxy/client.py
@@ -157,7 +157,7 @@ async def tcp_handler(reader: asyncio.StreamReader,
                 line = await reader.readline()
             if line:
                 parse_line(line)
-        except asyncio.TimeoutError:
+        except (asyncio.CancelledError, asyncio.TimeoutError):
             log.info('Client connection closed after timeout')
             break
         except ConnectionResetError:


### PR DESCRIPTION
`async_timeout.timeout` raise `asyncio.TimeoutError`, not `asyncio.CancelledError`.
https://github.com/aio-libs/async-timeout/blob/28f96b7197f58a7642d140005a92887834cbaf8c/async_timeout/__init__.py#L92